### PR TITLE
Correction pour le lien SONOS / ZDNet

### DIFF
--- a/content/sechebdo/2017-08-29-sechebdo-29-aout-2017.md
+++ b/content/sechebdo/2017-08-29-sechebdo-29-aout-2017.md
@@ -83,7 +83,7 @@ A bientôt pour d'autres émissions/podcasts!
 * Sarahah collecte vos données perso mais il parait que ça \"sarahrien\" :=D
     * [Beware! Viral Sarahah App Secretly Steals Your Entire Contact List](https://thehackernews.com/2017/08/sarahah-privacy.html)
 * SONOS : la définition du marche ou ... crève
-    * [Sonos says users must accept new privacy policy or devices may "cease to function"](Sonos says users must accept new privacy policy or devices may "cease to function")
+    * [Sonos says users must accept new privacy policy or devices may "cease to function"](http://www.zdnet.com/article/sonos-accept-new-privacy-policy-speakers-cease-to-function/)
     * [Sonos, Inc. Privacy Statement : our policy, your privacy](http://www.sonos.com/en-us/legal/privacy#functional-data)
 * Watermarks++ avec Philips Hue
     * [Philips imagine contrer le piratage issu des cinémas grâce à ses ampoules Ambilight](http://www.numerama.com/tech/284338-philips-imagine-contrer-le-piratage-issu-des-cinemas-grace-a-ses-ampoules-ambilight.htm)


### PR DESCRIPTION
Bonjour,

Je vous propose une correction pour le lien ZDNet dur SONOS.

Pas possible de mettre du https, ZDNet ne semblant pas avoir pris l'option chez Akamaï. :)

Bonne journée,

Thierry